### PR TITLE
Add tidal to JSON API

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -36,7 +36,8 @@ class Convert(View):
             'apple': music_obj.apple_url,
             'gpm': music_obj.gpm_url,
             'soundcloud': music_obj.soundcloud_url,
-            'spotify': music_obj.spotify_url
+            'spotify': music_obj.spotify_url,
+            'tidal': music_obj.tidal_url
         }
 
         if music_obj.music_type == 'T':


### PR DESCRIPTION
The JSON API which powers [my telegram bot](https://github.com/nicholasRutherford/BeatnikBot) doesn't have a TIDAL url which saddens me now that I have ascended to Tidal. I think this should do the trick?

This is untested because I was too lazy to register API keys.